### PR TITLE
Update demo.py: fix inference OOM error

### DIFF
--- a/main/demo.py
+++ b/main/demo.py
@@ -179,7 +179,7 @@ def main():
                     out_list.append(out.cpu().numpy().squeeze(0))
                 out = merge_out_list(out_list, fps)
                 out = loss_module.get_vertices(torch.from_numpy(out).cuda(), annot_type)
-                out_dict[wav_f][dataset_name] = out 
+                out_dict[wav_f][dataset_name] = out.cpu() 
         print(f"save results to {out_npz_path}")
         np.savez(out_npz_path, **out_dict)
 


### PR DESCRIPTION
Hi, thanks for open-sourcing such wonderful work!

I noticed that once the number of inference audio increases, it will run into the OOM error because all the predictions are saved in GPU. 

The solution is to move the predictions to cpu as `out_dict[wav_f][dataset_name] = out.cpu()`. 